### PR TITLE
cast to nx digraph to avoid pickling errors

### DIFF
--- a/chebi_utils/obo_extractor.py
+++ b/chebi_utils/obo_extractor.py
@@ -143,9 +143,11 @@ def build_chebi_graph(filepath: str | Path, top_class: str | None = "23367") -> 
 def get_hierarchy_subgraph(chebi_graph: nx.DiGraph) -> nx.DiGraph:
     """Subgraph of ChEBI including only edges corresponding to hierarchical relations (is_a).
     Also removes nodes that are not connected by any is_a edges to other nodes."""
-    return nx.DiGraph(chebi_graph.edge_subgraph(
-        (u, v) for u, v, d in chebi_graph.edges(data=True) if d.get("relation") == "is_a"
-    ))
+    return nx.DiGraph(
+        chebi_graph.edge_subgraph(
+            (u, v) for u, v, d in chebi_graph.edges(data=True) if d.get("relation") == "is_a"
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/chebi_utils/obo_extractor.py
+++ b/chebi_utils/obo_extractor.py
@@ -136,17 +136,16 @@ def build_chebi_graph(filepath: str | Path, top_class: str | None = "23367") -> 
     if top_class not in hierarchy:
         return graph
 
-    chebi_subgraph = graph.subgraph(nx.ancestors(hierarchy, top_class))
-    assert isinstance(chebi_subgraph, nx.DiGraph)
+    chebi_subgraph = nx.DiGraph(graph.subgraph(nx.ancestors(hierarchy, top_class)))
     return chebi_subgraph
 
 
 def get_hierarchy_subgraph(chebi_graph: nx.DiGraph) -> nx.DiGraph:
     """Subgraph of ChEBI including only edges corresponding to hierarchical relations (is_a).
     Also removes nodes that are not connected by any is_a edges to other nodes."""
-    return chebi_graph.edge_subgraph(
+    return nx.DiGraph(chebi_graph.edge_subgraph(
         (u, v) for u, v, d in chebi_graph.edges(data=True) if d.get("relation") == "is_a"
-    )
+    ))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When trying to save the chebi_graph to a pickle file, I got this error: 

```
AttributeError: Can't get local object 'show_diedges.<locals>.<lambda>'
```

Apparently, the `edge_subgraph` function attaches a lambda function to the graph that is not pickle-able. Casting it back to a regular DiGraph solves the issue